### PR TITLE
deprecatednomatch

### DIFF
--- a/R/attributes.R
+++ b/R/attributes.R
@@ -22,6 +22,7 @@ check_attributes <- function(x,
                              class = TRUE,
                              x_name = substitute(x),
                              error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_attributes()", NULL)
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(names)
@@ -62,6 +63,7 @@ check_no_attributes <- function(x,
                                 class = TRUE,
                                 x_name = substitute(x),
                                 error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_no_attributes()", NULL)
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(error)

--- a/R/classes.R
+++ b/R/classes.R
@@ -22,9 +22,8 @@ check_classes <- function(x, classes = character(0),
                      order = FALSE,
                      x_name = substitute(x),
                      error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_classes()", NULL,
-                            "Please use chk::check_s3_class() or chk::check_s4_class() instead. 
-Use chk::chk_s3_class() or chk::chk_s4_class() for faster versions which return NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_classes()", "chk::check_is()",
+                            "Use chk::chk_is() for a faster version which returns NULL.")
   
   x_name <- chk_deparse(x_name)
   

--- a/R/colnames.R
+++ b/R/colnames.R
@@ -20,6 +20,7 @@
 check_colnames <- function(x, colnames = character(0), exclusive = FALSE, order = FALSE,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_colnames()", "chk::check_data()")
 
   x_name <- chk_deparse(x_name)
 

--- a/R/colnames.R
+++ b/R/colnames.R
@@ -20,7 +20,7 @@
 check_colnames <- function(x, colnames = character(0), exclusive = FALSE, order = FALSE,
                          x_name = substitute(x),
                          error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_colnames()", "chk::check_data()")
+  lifecycle::deprecate_soft("0.5.1", "check_colnames()", "chk::check_names()")
 
   x_name <- chk_deparse(x_name)
 

--- a/R/dttm.R
+++ b/R/dttm.R
@@ -41,6 +41,8 @@ check_datetime <- function(x,
                            tzone = "",
                            x_name = substitute(x),
                            error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_datetime()", "chk::check_datetime()",
+                            "Use chk::chk_datetime() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_dttm(x, coerce = coerce, tzone = tzone, 

--- a/R/dttm.R
+++ b/R/dttm.R
@@ -16,8 +16,8 @@
 check_dttm <- function(x, coerce = FALSE, tzone = "UTC",
                        x_name = substitute(x),
                        error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_dttm()", "chk::check_datetime()",
-                            "Use chk::chk_datetime() for a faster version which returns NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_dttm()", "chk::check_date_time()",
+                            "Use chk::chk_date_time() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(coerce)
@@ -41,8 +41,8 @@ check_datetime <- function(x,
                            tzone = "",
                            x_name = substitute(x),
                            error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_datetime()", "chk::check_datetime()",
-                            "Use chk::chk_datetime() for a faster version which returns NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_datetime()", "chk::check_date_time()",
+                            "Use chk::chk_date_time() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_dttm(x, coerce = coerce, tzone = tzone, 

--- a/R/function.R
+++ b/R/function.R
@@ -14,6 +14,8 @@ check_function <- function(x,
                            nargs = NA,
                            x_name = substitute(x),
                            error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_function()", "chk::check_function()",
+                            "Use chk::chk_function() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_length_internal(nargs)

--- a/R/homogenous.R
+++ b/R/homogenous.R
@@ -19,8 +19,7 @@ check_homogenous <- function(x,
                              recursive = FALSE,
                              x_name = substitute(x),
                              error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_homogenous()", "chk::check_is()",
-                            "Use chk::chk_is() for a faster version which returns NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_homogenous()", NULL)
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(strict)

--- a/R/homogenous.R
+++ b/R/homogenous.R
@@ -19,6 +19,8 @@ check_homogenous <- function(x,
                              recursive = FALSE,
                              x_name = substitute(x),
                              error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_homogenous()", "chk::check_is()",
+                            "Use chk::chk_is() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(strict)

--- a/R/inherits.R
+++ b/R/inherits.R
@@ -15,6 +15,8 @@
 check_inherits <- function(x, class,
                      x_name = substitute(x),
                      error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_inherits()", "chk::check_is()",
+                            "Use chk::chk_is() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_string_internal(class)

--- a/R/int.R
+++ b/R/int.R
@@ -16,6 +16,8 @@
 check_int <- function(x, coerce = FALSE,
                       x_name = substitute(x),
                       error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_int()", "chk::check_integer()",
+                            "Use chk::chk_integer() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(coerce)
@@ -47,6 +49,9 @@ check_int <- function(x, coerce = FALSE,
 check_pos_int <- function(x, coerce = FALSE,
                       x_name = substitute(x),
                       error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_pos_int()", NULL,
+                            "Please use chk::check_integer() and chk::check_range() instead. 
+Use chk::chk_integer() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(coerce)
@@ -76,6 +81,9 @@ check_pos_int <- function(x, coerce = FALSE,
 check_neg_int <- function(x, coerce = FALSE,
                       x_name = substitute(x),
                       error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_neg_int()", NULL,
+                            "Please use chk::check_integer() and chk::check_range() instead. 
+Use chk::chk_integer() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(coerce)
@@ -106,6 +114,9 @@ check_neg_int <- function(x, coerce = FALSE,
 check_noneg_int <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_noneg_int()", NULL,
+                            "Please use chk::check_integer() and chk::check_range() instead. 
+Use chk::chk_integer() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(coerce)
@@ -138,6 +149,9 @@ check_noneg_int <- function(x, coerce = FALSE,
 check_count <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_count()", NULL,
+                            "Please use chk::check_whole_number() and chk::check_integer() instead. 
+Use chk::chk_whole_number() and chk::chk_integer() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
   
   check_noneg_int(x = x, coerce = coerce, x_name = x_name, error = error)

--- a/R/int.R
+++ b/R/int.R
@@ -150,8 +150,8 @@ check_count <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
   lifecycle::deprecate_soft("0.5.1", "check_count()", NULL,
-                            "Please use chk::check_whole_number() and chk::check_integer() instead. 
-Use chk::chk_whole_number() and chk::chk_integer() for faster versions which return NULL.")
+                            "Please use chk::check_whole_number() and chk::check_range() instead. 
+Use chk::chk_whole_number() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
   
   check_noneg_int(x = x, coerce = coerce, x_name = x_name, error = error)

--- a/R/intersection.R
+++ b/R/intersection.R
@@ -20,8 +20,7 @@ check_intersection <- function(x, y,
                        x_name = substitute(x),
                        y_name = substitute(y),
                        error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_intersection()", "chk::check_join()",
-                            "Use chk::chk_join() for a faster version which returns NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_intersection()", NULL)
   x_name <- chk_deparse(x_name)
   y_name <- chk_deparse(y_name)
   

--- a/R/intersection.R
+++ b/R/intersection.R
@@ -20,6 +20,8 @@ check_intersection <- function(x, y,
                        x_name = substitute(x),
                        y_name = substitute(y),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_intersection()", "chk::check_join()",
+                            "Use chk::chk_join() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   y_name <- chk_deparse(y_name)
   

--- a/R/length.R
+++ b/R/length.R
@@ -45,6 +45,7 @@ check_length <- function(x,
 check_length1 <- function(x,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_length1()", "chk::check_dim()")
   x_name <- chk_deparse(x_name)
 
   check_length(x, length = 1L, x_name = x_name, error = error)

--- a/R/levels.R
+++ b/R/levels.R
@@ -18,6 +18,7 @@
 check_levels <- function(x, levels, exclusive = TRUE, order = TRUE,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_levels()", "chk::check_dim()")
   x_name <- chk_deparse(x_name)
 
   check_vector(levels, "", length = c(1L, chk_max_int()), unique = FALSE, named = FALSE)

--- a/R/missing-colnames.R
+++ b/R/missing-colnames.R
@@ -17,6 +17,7 @@
 check_missing_colnames <- function(x, colnames, 
                                    x_name = substitute(x),
                                    error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_missing_colnames()", "chk::check_names()")
   
   x_name <- chk_deparse(x_name)
   

--- a/R/missing-names.R
+++ b/R/missing-names.R
@@ -17,6 +17,7 @@
 check_missing_names <- function(x, names, 
                                    x_name = substitute(x),
                                    error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_missing_names()", "chk::check_names()")
   
   x_name <- chk_deparse(x_name)
   

--- a/R/name.R
+++ b/R/name.R
@@ -12,6 +12,7 @@
 #' vec <- c("x", "x.y", "x y")
 #' check_name(vec, error = FALSE)
 check_name <- function(x, x_name = substitute(x), coerce = FALSE, error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_name()", "chk::check_names()")
   x_name <- chk_deparse(x_name)
   
   check_flag_internal(coerce)

--- a/R/nchar.R
+++ b/R/nchar.R
@@ -13,6 +13,7 @@
 #' check_nchar(c("foo", "bar"), nchar = 3)
 check_nchar <- function(x, nchar = TRUE, x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_nchar()", NULL)
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(error)

--- a/R/ncol.R
+++ b/R/ncol.R
@@ -15,6 +15,7 @@
 check_ncol <- function(x, ncol = TRUE,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_ncol()", "chk::check_data()")
   x_name <- chk_deparse(x_name)
 
   check_length_internal(ncol)

--- a/R/ncol.R
+++ b/R/ncol.R
@@ -15,7 +15,7 @@
 check_ncol <- function(x, ncol = TRUE,
                          x_name = substitute(x),
                          error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_ncol()", "chk::check_data()")
+  lifecycle::deprecate_soft("0.5.1", "check_ncol()", "chk::check_dim()")
   x_name <- chk_deparse(x_name)
 
   check_length_internal(ncol)

--- a/R/nrow.R
+++ b/R/nrow.R
@@ -17,7 +17,7 @@
 check_nrow <- function(x, nrow = TRUE,
                          x_name = substitute(x),
                          error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_nrow()", "chk::check_data()")
+  lifecycle::deprecate_soft("0.5.1", "check_nrow()", "chk::check_dim()")
   x_name <- chk_deparse(x_name)
 
   check_length_internal(nrow)

--- a/R/nrow.R
+++ b/R/nrow.R
@@ -17,6 +17,7 @@
 check_nrow <- function(x, nrow = TRUE,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_nrow()", "chk::check_data()")
   x_name <- chk_deparse(x_name)
 
   check_length_internal(nrow)

--- a/R/prob.R
+++ b/R/prob.R
@@ -16,6 +16,9 @@
 check_prob <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_prob()", NULL,
+                            "Please use chk::check_dbl() and chk::check_range() instead. 
+Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(coerce)
@@ -34,6 +37,9 @@ check_prob <- function(x, coerce = FALSE,
 check_probability <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_probability()", NULL,
+                            "Please use chk::check_dbl() and chk::check_range() instead. 
+Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_prob(x, coerce = coerce, x_name = x_name, error = error)
@@ -44,6 +50,9 @@ check_probability <- function(x, coerce = FALSE,
 check_prop <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_prop()", NULL,
+                            "Please use chk::check_dbl() and chk::check_range() instead. 
+Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_prob(x, coerce = coerce, x_name = x_name, error = error)

--- a/R/prob.R
+++ b/R/prob.R
@@ -17,7 +17,7 @@ check_prob <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
   lifecycle::deprecate_soft("0.5.1", "check_prob()", NULL,
-                            "Please use chk::check_dbl() and chk::check_range() instead. 
+                            "Please use chk::check_double() and chk::check_range() instead. 
 Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
@@ -38,8 +38,8 @@ check_probability <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
   lifecycle::deprecate_soft("0.5.1", "check_probability()", NULL,
-                            "Please use chk::check_dbl() and chk::check_range() instead. 
-Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
+                            "Please use chk::check_double() and chk::check_range() instead. 
+Use chk::chk_double() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_prob(x, coerce = coerce, x_name = x_name, error = error)
@@ -51,8 +51,8 @@ check_prop <- function(x, coerce = FALSE,
                        x_name = substitute(x),
                        error = TRUE) {
   lifecycle::deprecate_soft("0.5.1", "check_prop()", NULL,
-                            "Please use chk::check_dbl() and chk::check_range() instead. 
-Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
+                            "Please use chk::check_double() and chk::check_range() instead. 
+Use chk::chk_double() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_prob(x, coerce = coerce, x_name = x_name, error = error)

--- a/R/props.R
+++ b/R/props.R
@@ -8,6 +8,9 @@
 #' @export
 check_props <- function(x, x_name = substitute(x),
                        error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_props()", NULL,
+                            "Please use chk::check_dbl() and chk::check_range() instead. 
+Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(error)

--- a/R/props.R
+++ b/R/props.R
@@ -9,8 +9,8 @@
 check_props <- function(x, x_name = substitute(x),
                        error = TRUE) {
   lifecycle::deprecate_soft("0.5.1", "check_props()", NULL,
-                            "Please use chk::check_dbl() and chk::check_range() instead. 
-Use chk::chk_dbl() and chk::chk_range() for faster versions which return NULL.")
+                            "Please use chk::check_double() and chk::check_range() instead. 
+Use chk::chk_double() and chk::chk_range() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(error)

--- a/R/rbind.R
+++ b/R/rbind.R
@@ -20,6 +20,8 @@ check_rbind <- function(x,
                         x_name = substitute(x),
                         y_name = substitute(y),
                         error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_rbind()", "chk::check_join()",
+                            "Use chk::chk_join() for a faster version which returns NULL.")
   x_name <- chk_deparse(x_name)
   y_name <- chk_deparse(y_name)
   

--- a/R/rbind.R
+++ b/R/rbind.R
@@ -20,8 +20,7 @@ check_rbind <- function(x,
                         x_name = substitute(x),
                         y_name = substitute(y),
                         error = TRUE) {
-  lifecycle::deprecate_soft("0.5.1", "check_rbind()", "chk::check_join()",
-                            "Use chk::chk_join() for a faster version which returns NULL.")
+  lifecycle::deprecate_soft("0.5.1", "check_rbind()", NULL)
   x_name <- chk_deparse(x_name)
   y_name <- chk_deparse(y_name)
   

--- a/R/unnamed.R
+++ b/R/unnamed.R
@@ -16,6 +16,9 @@
 check_unnamed <- function(x,
                          x_name = substitute(x),
                          error = TRUE) {
+  lifecycle::deprecate_soft("0.5.1", "check_unnamed()", NULL,
+                            "Please use chk::check_named() or chk::check_not_empty() instead. 
+Use chk::chk_named() and chk::chk_not_empty() for faster versions which return NULL.")
   x_name <- chk_deparse(x_name)
 
   check_flag_internal(error)

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -1,4 +1,5 @@
 test_that("check_attributes", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- 1
   attributes(x) <- list(y = 2L)
   expect_error(check_attributes(x, values = list(y = 3:4)),
@@ -16,6 +17,7 @@ test_that("check_attributes", {
 })
 
 test_that("check_no_attributes", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- 1
   expect_identical(check_no_attributes(x), x)
   attributes(x) <- list(y = 2L)

--- a/tests/testthat/test-colnames.R
+++ b/tests/testthat/test-colnames.R
@@ -1,5 +1,5 @@
 test_that("colnames", {
-  
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   data <- data.frame(x = 1, y = 2, z = 0)
   expect_identical(check_colnames(data, c("y", "x")), data)
   

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -1,4 +1,5 @@
 test_that("check_count errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   y <- 2L
   expect_identical(check_count(y), y)
   y <- 2
@@ -11,6 +12,7 @@ test_that("check_count errors", {
 })
 
 test_that("check_count coercion", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_error(check_count(1), "1 must be class integer")
   expect_identical(check_count(1, coerce = TRUE), 1L)
   expect_error(check_count(c(1,1), coerce = TRUE), "c[(]1, 1[)] must have 1 element")

--- a/tests/testthat/test-homogenous.R
+++ b/tests/testthat/test-homogenous.R
@@ -1,4 +1,5 @@
 test_that("length1", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_homogenous(2), 2)
   expect_identical(check_homogenous(list(1)), list(1))
   

--- a/tests/testthat/test-inherits.R
+++ b/tests/testthat/test-inherits.R
@@ -1,4 +1,5 @@
 test_that("check_inherits", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- list()
   class(x) <- c("a", "b")
   

--- a/tests/testthat/test-int.R
+++ b/tests/testthat/test-int.R
@@ -1,4 +1,5 @@
 test_that("check_int errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   y <- 2L
   expect_identical(check_int(y), y)
   y <- 2
@@ -14,6 +15,7 @@ test_that("check_int errors", {
 })
 
 test_that("check_pos_int", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_pos_int(1L, error = FALSE), 1L)
   expect_error(check_pos_int(0, error = TRUE), "0 must be class integer")
   expect_error(check_pos_int(1:2, error = TRUE), "1:2 must have 1 element")
@@ -24,6 +26,7 @@ test_that("check_pos_int", {
 })
 
 test_that("check_neg_int", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_neg_int(-1L, error = FALSE), -1L)
   expect_error(check_neg_int(0, error = TRUE), "0 must be class integer")
   expect_error(check_neg_int(-1:-2, error = TRUE), "-1:-2 must have 1 element")
@@ -34,6 +37,7 @@ test_that("check_neg_int", {
 })
 
 test_that("check_integer", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_integer(1L, error = FALSE), 1L)
   expect_identical(check_integer(-1L, error = FALSE), -1L)
   expect_error(check_integer(0.5, error = TRUE), "0.5 must be class integer")

--- a/tests/testthat/test-intersection.R
+++ b/tests/testthat/test-intersection.R
@@ -1,4 +1,5 @@
 test_that("check_intersection", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x1 <- 1:3
   x2 <- 1:4
   expect_identical(check_intersection(x1, x2), x1)

--- a/tests/testthat/test-levels.R
+++ b/tests/testthat/test-levels.R
@@ -1,11 +1,12 @@
 test_that("levels", {
-
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_error(check_levels(1, c("y", "x")), "1 must have a levels attribute")
   expect_error(check_levels(factor(1), c("y", "x")), "factor[(]1[)] levels must be identical to 'y' and 'x'")
   expect_identical(check_levels(factor(1), "1"), factor(1))
 })
 
 test_that("levels errors for order and exclusive args", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- factor(c("a", "b", "c"), levels = c("a", "b", "c"))
   
   expect_error(check_levels(x, exclusive = FALSE, levels = c("b", "c", "a")),

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -1,10 +1,12 @@
 test_that("missing", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   data <- data.frame(x = 1, y = 2, z = 0)
   expect_identical(check_missing_colnames(data, "a"), data)
   expect_error(check_missing_colnames(data, c("y", "x", "a")), "data must not have columns 'x' and 'y'")
 })
   
 test_that("missing names errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   vec <- c(x = 1, y = 2, z = 0)
   expect_error(check_missing_names(vec, c("x", "y", "a"), error = TRUE), "vec must not have names 'x' and 'y'")
   expect_identical(check_missing_names(vec, "a", error = TRUE), vec)

--- a/tests/testthat/test-name.R
+++ b/tests/testthat/test-name.R
@@ -1,5 +1,5 @@
 test_that("name", {
-  
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   vec <- c("x", "x.y")
   expect_identical(check_name(vec), vec)
   

--- a/tests/testthat/test-nas.R
+++ b/tests/testthat/test-nas.R
@@ -1,4 +1,5 @@
 test_that("nas", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_nas(NA, NA), NA)
   expect_identical(check_nas(c(TRUE, NA), c(FALSE, NA)), c(TRUE, NA))
   expect_error(check_nas(c(TRUE, NA), NA), "c[(]TRUE, NA[)] must only include missing values")

--- a/tests/testthat/test-nchar.R
+++ b/tests/testthat/test-nchar.R
@@ -1,4 +1,5 @@
 test_that("nchar", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_nchar(1), 1)
   expect_identical(check_nchar(1, 1), 1)
   expect_error(check_nchar(1, 2), "1 must have 2 characters")

--- a/tests/testthat/test-ncol.R
+++ b/tests/testthat/test-ncol.R
@@ -1,4 +1,5 @@
 test_that("check_ncol requires a data frame", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_ncol(x), x)
   y <- NULL
@@ -6,6 +7,7 @@ test_that("check_ncol requires a data frame", {
 })
 
 test_that("check_ncol requires counts", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_ncol(x), x)
   expect_error(check_ncol(x, ncol = -1), "ncol must be a flag, a missing value, a count, a count range or a count vector")
@@ -13,6 +15,7 @@ test_that("check_ncol requires counts", {
 })
 
 test_that("check_ncol checks ncol", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_ncol(x), x)
   expect_error(check_ncol(x, ncol = c(2,2)), "x must have at least 2 columns")

--- a/tests/testthat/test-nrow.R
+++ b/tests/testthat/test-nrow.R
@@ -1,4 +1,5 @@
 test_that("check_nrow requires a data frame", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_nrow(x), x)
   y <- NULL
@@ -6,6 +7,7 @@ test_that("check_nrow requires a data frame", {
 })
 
 test_that("check_nrow requires counts", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_nrow(x), x)
   expect_error(check_nrow(x, nrow = -1), "nrow must be a flag, a missing value, a count, a count range or a count vector")
@@ -13,6 +15,7 @@ test_that("check_nrow requires counts", {
 })
 
 test_that("check_nrow checks nrow", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- data.frame(y = 2)
   expect_identical(check_nrow(x), x)
   expect_error(check_nrow(x, nrow = 2), "x must have 2 rows")

--- a/tests/testthat/test-ordered.R
+++ b/tests/testthat/test-ordered.R
@@ -1,4 +1,5 @@
 test_that("class", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   ordered <- ordered(c("1", "3", "0"))
   factor <- factor(c("1", "3", "0"))
   
@@ -9,6 +10,7 @@ test_that("class", {
 })
 
 test_that("levels", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   ordered <- ordered(c("1", "3", "0"))
   factor <- factor(c("1", "3", "0"))
   

--- a/tests/testthat/test-prob.R
+++ b/tests/testthat/test-prob.R
@@ -1,4 +1,5 @@
 test_that("check_prob errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   y <- 1.0
   expect_identical(check_prob(y), y)
   y <- 1L
@@ -15,6 +16,7 @@ test_that("check_prob errors", {
 })
 
 test_that("check_props errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   vec <- c(0.5, 0.5)
   expect_identical(check_props(vec), vec)
   vec <- c(1.0, 1.0)
@@ -22,6 +24,7 @@ test_that("check_props errors", {
 })
 
 test_that("check_prop errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   vec <- c(0.5)
   expect_identical(check_prop(vec), vec)
   vec <- c(1.1)
@@ -31,6 +34,7 @@ test_that("check_prop errors", {
 })
 
 test_that("check_probability errors", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   vec <- c(0.5)
   expect_identical(check_probability(vec), vec)
   vec <- c(1.1)

--- a/tests/testthat/test-rbind.R
+++ b/tests/testthat/test-rbind.R
@@ -1,4 +1,5 @@
 test_that("rbind column names", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_rbind(datasets::mtcars, datasets::mtcars), datasets::mtcars)
   expect_identical(check_rbind(datasets::mtcars[c("cyl", "mpg")], 
                                datasets::mtcars[c("mpg", "cyl")]),
@@ -17,6 +18,7 @@ test_that("rbind column names", {
 })
 
 test_that("rbind column names", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   x <- datasets::mtcars[c("cyl", "mpg")]
   y <- x
   expect_identical(check_rbind(x, y), x)

--- a/tests/testthat/test-unnamed.R
+++ b/tests/testthat/test-unnamed.R
@@ -1,4 +1,5 @@
 test_that("unnamed", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
   expect_identical(check_unnamed(2), 2)
   x <- 1
   names(x) <- "y"


### PR DESCRIPTION
Functions not yet deprecated:
- `check_attributes`
- `check_no_attributes`
- `check_levels`
- `check_nchar`