### PR TITLE
Updating R CMD check Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,6 @@ jobs:
           - {os: ubuntu-latest, r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-latest, r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-latest, r: '3.5', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-latest, r: '3.4', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/man/checkr-package.Rd
+++ b/man/checkr-package.Rd
@@ -6,10 +6,7 @@
 \alias{checkr-package}
 \title{checkr: Check the Properties of Common R Objects}
 \description{
-Expressive, assertive, pipe-friendly functions 
-  to check the properties of common R objects.
-  In the case of failure the functions issue informative error messages.
-  Superseded by the 'chk' package.
+Expressive, assertive, pipe-friendly functions to check the properties of common R objects. In the case of failure the functions issue informative error messages. Superseded by the 'chk' package.
 }
 \seealso{
 \code{\link{check_vector}}, \code{\link{check_list}} and \code{\link{check_data}}


### PR DESCRIPTION
Removed checks for R version 3.4 from the R-CMD-check file as the package depends on version of R 3.5 and greater.  

Please wait until confirmation of merger. Waiting for proper checks to pass. Referencing previous errors with current errors for proper diagnoses of issue.  
