### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.5.0.9001
 Authors@R: 
     c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut", "cre"), comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", "ctb", comment = c(ORCID = 0000-0003-1096-2089)),
+    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", "ctb", comment = c(ORCID = "0000-0003-1096-2089")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )
 Description: Expressive, assertive, pipe-friendly functions 


### PR DESCRIPTION
Quote Evan Amies-Galonski's ORCID (it was unquoted, so R evaluated it as arithmetic and the ORCID was silently dropped).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)