### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.5.0.9001
 Authors@R: 
     c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut", "cre"), comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", "ctb", comment = c(ORCID = 0000-0003-1096-2089)),
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", "ctb", comment = c(ORCID = 0000-0003-1096-2089)),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )
 Description: Expressive, assertive, pipe-friendly functions 


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.